### PR TITLE
Add white/black start buttons

### DIFF
--- a/app/src/main/java/de/brockmann/chessinterface/MenuAIActivity.java
+++ b/app/src/main/java/de/brockmann/chessinterface/MenuAIActivity.java
@@ -2,6 +2,7 @@ package de.brockmann.chessinterface;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.Button;
 import android.widget.SeekBar;
 import android.widget.TextView;
@@ -22,7 +23,8 @@ public class MenuAIActivity extends MenuActivity {
 
         SeekBar seekBar = findViewById(R.id.seekBar_strength);
         TextView valueView = findViewById(R.id.tv_strength_value);
-        Button startBtn = findViewById(R.id.btn_start_ai);
+        Button whiteBtn = findViewById(R.id.btn_start_ai_white);
+        Button blackBtn = findViewById(R.id.btn_start_ai_black);
 
         // update label when slider moves
         seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
@@ -36,11 +38,14 @@ public class MenuAIActivity extends MenuActivity {
         });
 
         // launch AI game with chosen strength
-        startBtn.setOnClickListener(v -> {
+        View.OnClickListener startListener = v -> {
             int strength = 800 + seekBar.getProgress();
             Intent intent = new Intent(this, AIChessActivity.class);
             intent.putExtra(EXTRA_AI_STRENGTH, strength);
             startActivity(intent);
-        });
+        };
+
+        whiteBtn.setOnClickListener(startListener);
+        blackBtn.setOnClickListener(startListener);
     }
 }

--- a/app/src/main/res/layout/menu_ai_activity.xml
+++ b/app/src/main/res/layout/menu_ai_activity.xml
@@ -45,10 +45,28 @@
         android:textSize="16sp"
         android:layout_marginBottom="32dp"/>
 
-    <!-- start button -->
-    <Button
-        android:id="@+id/btn_start_ai"
+    <!-- start buttons -->
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Spiel starten"/>
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/btn_start_ai_white"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@color/white"
+            android:text="Weiß"
+            android:textColor="@color/black"/>
+
+        <Button
+            android:id="@+id/btn_start_ai_black"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@color/black"
+            android:text="Schwarz"
+            android:textColor="@color/white"/>
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
## Summary
- update MenuAI layout with two start buttons
- wire new buttons in MenuAIActivity

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684bf3b192f48333b56b98918bfdaf25