### PR TITLE
Add game end overlay

### DIFF
--- a/app/src/main/res/layout/chess_activity.xml
+++ b/app/src/main/res/layout/chess_activity.xml
@@ -74,4 +74,51 @@
             android:layout_marginStart="8dp"
             android:text="Resign"/>
     </LinearLayout>
+
+    <!-- Overlay shown when the game is finished -->
+    <FrameLayout
+        android:id="@+id/game_end_overlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#88000000"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:orientation="vertical"
+            android:padding="16dp"
+            android:background="@android:color/white"
+            android:gravity="center">
+
+            <TextView
+                android:id="@+id/tv_game_end_message"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Game Over"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                android:gravity="center" />
+
+            <Button
+                android:id="@+id/btn_new_game"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="New Game" />
+
+            <Button
+                android:id="@+id/btn_main_menu"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="Main Menu" />
+
+        </LinearLayout>
+    </FrameLayout>
 </merge>


### PR DESCRIPTION
## Summary
- overlay for game end with new and main menu buttons
- wire overlay controls in `ChessActivity`
- show overlay instead of Toast on game completion

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68551a7807008333a24bd5e6e14a571e