### PR TITLE
Add settings menu with dark mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="de.brockmann.chessinterface">
 
     <application
+        android:name=".ChessApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -47,6 +48,11 @@
         <activity android:name=".MenuAIActivity"
             android:exported="false"
             android:label="Local Chess Game" >
+        </activity>
+
+        <activity android:name=".SettingsMenuActivity"
+            android:exported="false"
+            android:label="Settings" >
         </activity>
 
         <activity

--- a/app/src/main/java/de/brockmann/chessinterface/ChessApplication.java
+++ b/app/src/main/java/de/brockmann/chessinterface/ChessApplication.java
@@ -1,0 +1,17 @@
+package de.brockmann.chessinterface;
+
+import android.app.Application;
+import android.content.SharedPreferences;
+import androidx.appcompat.app.AppCompatDelegate;
+
+public class ChessApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        SharedPreferences prefs = getSharedPreferences("prefs", MODE_PRIVATE);
+        boolean enabled = prefs.getBoolean("dark_mode", false);
+        AppCompatDelegate.setDefaultNightMode(
+                enabled ? AppCompatDelegate.MODE_NIGHT_YES
+                        : AppCompatDelegate.MODE_NIGHT_NO);
+    }
+}

--- a/app/src/main/java/de/brockmann/chessinterface/MainActivity.java
+++ b/app/src/main/java/de/brockmann/chessinterface/MainActivity.java
@@ -28,5 +28,9 @@ public class MainActivity extends MenuActivity {
         findViewById(R.id.btn_analysis)
                 .setOnClickListener(v ->
                         startActivity(new Intent(this, AnalysisChessActivity.class)));
+
+        findViewById(R.id.btn_settings)
+                .setOnClickListener(v ->
+                        startActivity(new Intent(this, SettingsMenuActivity.class)));
     }
 }

--- a/app/src/main/java/de/brockmann/chessinterface/SettingsMenuActivity.java
+++ b/app/src/main/java/de/brockmann/chessinterface/SettingsMenuActivity.java
@@ -1,0 +1,30 @@
+package de.brockmann.chessinterface;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.appcompat.widget.SwitchCompat;
+
+public class SettingsMenuActivity extends MenuActivity {
+
+    @Override
+    protected int getContentLayoutId() {
+        return R.layout.menu_settings_activity;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        SwitchCompat darkSwitch = findViewById(R.id.switch_dark_mode);
+        SharedPreferences prefs = getSharedPreferences("prefs", MODE_PRIVATE);
+        boolean enabled = prefs.getBoolean("dark_mode", false);
+        darkSwitch.setChecked(enabled);
+        darkSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            prefs.edit().putBoolean("dark_mode", isChecked).apply();
+            AppCompatDelegate.setDefaultNightMode(
+                    isChecked ? AppCompatDelegate.MODE_NIGHT_YES
+                            : AppCompatDelegate.MODE_NIGHT_NO);
+        });
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,4 +24,11 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:text="Analyse" />
+
+    <Button
+        android:id="@+id/btn_settings"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Einstellungen" />
 </LinearLayout>

--- a/app/src/main/res/layout/menu_settings_activity.xml
+++ b/app/src/main/res/layout/menu_settings_activity.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_vertical"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Dark Mode"/>
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/switch_dark_mode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- create `ChessApplication` that sets night mode from prefs
- add `SettingsMenuActivity` with dark mode switch
- register new application class and activity in manifest
- include settings button in main menu layout and activity code

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68551b3de9f88333b308117f5da9e326