### PR TITLE
Switch logo in dark mode

### DIFF
--- a/app/src/main/res/layout/menu_activity.xml
+++ b/app/src/main/res/layout/menu_activity.xml
@@ -13,7 +13,7 @@
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
-        android:src="@drawable/brock_mate_light_mode"
+        android:src="?attr/appLogo"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -3,5 +3,6 @@
     <style name="Base.Theme.ChessInterface" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your dark theme here. -->
         <!-- <item name="colorPrimary">@color/my_dark_primary</item> -->
+        <item name="appLogo">@drawable/brock_mate_dark_mode</item>
     </style>
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,3 @@
+<resources>
+    <attr name="appLogo" format="reference" />
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,6 +3,7 @@
     <style name="Base.Theme.ChessInterface" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your light theme here. -->
         <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
+        <item name="appLogo">@drawable/brock_mate_light_mode</item>
     </style>
 
     <style name="Theme.ChessInterface" parent="Base.Theme.ChessInterface" />


### PR DESCRIPTION
## Summary
- add `appLogo` theme attribute to switch logo based on theme
- reference logo attribute from `menu_activity` layout
- include light and dark implementations of `appLogo`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6855237ba9f08333b0bf9e95f28b3b56