### PR TITLE
Add draw and resign overlays

### DIFF
--- a/app/src/main/java/de/brockmann/chessinterface/ChessActivity.java
+++ b/app/src/main/java/de/brockmann/chessinterface/ChessActivity.java
@@ -25,6 +25,8 @@ public abstract class ChessActivity extends AppCompatActivity {
     protected GridLayout chessBoardGrid;
     private View gameEndOverlay;
     private TextView gameEndMessage;
+    private View drawOfferOverlay;
+    private View resignConfirmOverlay;
 
     private final String[] initialBoardSetup = {
             "r", "n", "b", "q", "k", "b", "n", "r",
@@ -73,6 +75,8 @@ public abstract class ChessActivity extends AppCompatActivity {
 
         chessBoardGrid = findViewById(R.id.chess_board_grid);
         gameEndOverlay = findViewById(R.id.game_end_overlay);
+        drawOfferOverlay = findViewById(R.id.draw_offer_overlay);
+        resignConfirmOverlay = findViewById(R.id.resign_confirm_overlay);
         if (gameEndOverlay != null) {
             gameEndMessage = gameEndOverlay.findViewById(R.id.tv_game_end_message);
             Button newGame = gameEndOverlay.findViewById(R.id.btn_new_game);
@@ -86,6 +90,27 @@ public abstract class ChessActivity extends AppCompatActivity {
                         .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK));
                 finish();
             });
+        }
+
+        if (drawOfferOverlay != null) {
+            Button accept = drawOfferOverlay.findViewById(R.id.btn_accept_draw);
+            Button decline = drawOfferOverlay.findViewById(R.id.btn_decline_draw);
+            accept.setOnClickListener(v -> {
+                hideDrawOfferOverlay();
+                showGameEndOverlay("Draw agreed");
+            });
+            decline.setOnClickListener(v -> hideDrawOfferOverlay());
+        }
+
+        if (resignConfirmOverlay != null) {
+            Button yes = resignConfirmOverlay.findViewById(R.id.btn_resign_yes);
+            Button no = resignConfirmOverlay.findViewById(R.id.btn_resign_no);
+            yes.setOnClickListener(v -> {
+                hideResignConfirmOverlay();
+                String winner = currentPlayerTurn == 'W' ? "Black" : "White";
+                showGameEndOverlay(winner + " won by resignation");
+            });
+            no.setOnClickListener(v -> hideResignConfirmOverlay());
         }
         setupDummyButtons();
 
@@ -729,6 +754,30 @@ public abstract class ChessActivity extends AppCompatActivity {
     protected void hideGameEndOverlay() {
         if (gameEndOverlay != null) {
             gameEndOverlay.setVisibility(View.GONE);
+        }
+    }
+
+    protected void showDrawOfferOverlay() {
+        if (drawOfferOverlay != null) {
+            drawOfferOverlay.setVisibility(View.VISIBLE);
+        }
+    }
+
+    protected void hideDrawOfferOverlay() {
+        if (drawOfferOverlay != null) {
+            drawOfferOverlay.setVisibility(View.GONE);
+        }
+    }
+
+    protected void showResignConfirmOverlay() {
+        if (resignConfirmOverlay != null) {
+            resignConfirmOverlay.setVisibility(View.VISIBLE);
+        }
+    }
+
+    protected void hideResignConfirmOverlay() {
+        if (resignConfirmOverlay != null) {
+            resignConfirmOverlay.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/java/de/brockmann/chessinterface/LocalChessActivity.java
+++ b/app/src/main/java/de/brockmann/chessinterface/LocalChessActivity.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.ImageView;
 import android.widget.FrameLayout;
+import android.widget.Button;
 
 import java.util.Locale;
 
@@ -80,6 +81,11 @@ public class LocalChessActivity extends ChessActivity {
             // 5. Timer starten (nur weiß beginnt)
             startWhiteTimer();
         }
+
+        Button draw = findViewById(R.id.btn_offer_draw);
+        Button resign = findViewById(R.id.btn_resign_game);
+        if (draw != null) draw.setOnClickListener(v -> showDrawOfferOverlay());
+        if (resign != null) resign.setOnClickListener(v -> showResignConfirmOverlay());
     }
 
     // Converts a time control like "M" or "M|I"/"M+I" and stores increment

--- a/app/src/main/res/layout/chess_activity.xml
+++ b/app/src/main/res/layout/chess_activity.xml
@@ -75,6 +75,108 @@
             android:text="Resign"/>
     </LinearLayout>
 
+    <!-- Overlay shown when a draw is offered -->
+    <FrameLayout
+        android:id="@+id/draw_offer_overlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#88000000"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:orientation="vertical"
+            android:padding="16dp"
+            android:background="@android:color/white"
+            android:gravity="center">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Accept draw?"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:gravity="center" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="12dp">
+
+                <Button
+                    android:id="@+id/btn_accept_draw"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Accept" />
+
+                <Button
+                    android:id="@+id/btn_decline_draw"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:text="Decline" />
+            </LinearLayout>
+        </LinearLayout>
+    </FrameLayout>
+
+    <!-- Overlay shown to confirm resignation -->
+    <FrameLayout
+        android:id="@+id/resign_confirm_overlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#88000000"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:orientation="vertical"
+            android:padding="16dp"
+            android:background="@android:color/white"
+            android:gravity="center">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Resign?"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:gravity="center" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="12dp">
+
+                <Button
+                    android:id="@+id/btn_resign_yes"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Resign" />
+
+                <Button
+                    android:id="@+id/btn_resign_no"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:text="Cancel" />
+            </LinearLayout>
+        </LinearLayout>
+    </FrameLayout>
+
     <!-- Overlay shown when the game is finished -->
     <FrameLayout
         android:id="@+id/game_end_overlay"


### PR DESCRIPTION
## Summary
- add draw offer and resign confirmation overlays in `chess_activity.xml`
- wire up overlay behaviour in `ChessActivity`
- activate new overlays from `LocalChessActivity`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685526dc457883339576bc0e5a74dac4