### PR TITLE
Fix AI game activity crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
 
         <activity android:name=".AIChessActivity"
             android:exported="false"
-            android:label="Local Chess Game" >
+            android:label="AI Chess Game" >
         </activity>
 
         <activity android:name=".AnalysisChessActivity"

--- a/app/src/main/java/de/brockmann/chessinterface/AIChessActivity.java
+++ b/app/src/main/java/de/brockmann/chessinterface/AIChessActivity.java
@@ -7,11 +7,11 @@ import android.widget.ImageView;
 /**
  * Chess activity against the Stockfish engine.
  */
-public abstract class AIChessActivity extends ChessActivity {
+public class AIChessActivity extends ChessActivity {
 
     private StockfishClient engine;
     private int aiStrength;
-    private final char aiColor = 'B';
+    private char aiColor;
 
     @Override
     protected int getContentLayoutId() {
@@ -23,10 +23,16 @@ public abstract class AIChessActivity extends ChessActivity {
         super.onCreate(savedInstanceState);
 
         aiStrength = getIntent().getIntExtra(MenuAIActivity.EXTRA_AI_STRENGTH, 800);
+        aiColor = getIntent().getCharExtra(MenuAIActivity.EXTRA_AI_COLOR, 'B');
         engine = new StockfishClient();
         if (engine.start()) {
             engine.setElo(aiStrength);
         }
+        chessBoardGrid.post(() -> {
+            if (currentPlayerTurn == aiColor) {
+                makeAIMove();
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/de/brockmann/chessinterface/MenuAIActivity.java
+++ b/app/src/main/java/de/brockmann/chessinterface/MenuAIActivity.java
@@ -11,6 +11,8 @@ public class MenuAIActivity extends MenuActivity {
 
     public static final String EXTRA_AI_STRENGTH =
             "de.brockmann.chessinterface.EXTRA_AI_STRENGTH";
+    public static final String EXTRA_AI_COLOR =
+            "de.brockmann.chessinterface.EXTRA_AI_COLOR";
 
     @Override
     protected int getContentLayoutId() {
@@ -37,15 +39,16 @@ public class MenuAIActivity extends MenuActivity {
             @Override public void onStopTrackingTouch(SeekBar sb) {}
         });
 
-        // launch AI game with chosen strength
-        View.OnClickListener startListener = v -> {
-            int strength = 800 + seekBar.getProgress();
-            Intent intent = new Intent(this, AIChessActivity.class);
-            intent.putExtra(EXTRA_AI_STRENGTH, strength);
-            startActivity(intent);
-        };
+        whiteBtn.setOnClickListener(v -> startGame('W', seekBar.getProgress()));
+        blackBtn.setOnClickListener(v -> startGame('B', seekBar.getProgress()));
+    }
 
-        whiteBtn.setOnClickListener(startListener);
-        blackBtn.setOnClickListener(startListener);
+    private void startGame(char playerColor, int progress) {
+        int strength = 800 + progress;
+        Intent intent = new Intent(this, AIChessActivity.class);
+        intent.putExtra(EXTRA_AI_STRENGTH, strength);
+        char aiColor = playerColor == 'W' ? 'B' : 'W';
+        intent.putExtra(EXTRA_AI_COLOR, aiColor);
+        startActivity(intent);
     }
 }


### PR DESCRIPTION
## Summary
- make `AIChessActivity` a concrete class and start AI move if necessary
- let `MenuAIActivity` pass desired AI colour
- update manifest label for AI activity

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6855275cd13083339949518f8b091e99