### PR TITLE
Fix AnalysisChessActivity initialization

### DIFF
--- a/app/src/main/java/de/brockmann/chessinterface/AnalysisChessActivity.java
+++ b/app/src/main/java/de/brockmann/chessinterface/AnalysisChessActivity.java
@@ -42,7 +42,6 @@ public class AnalysisChessActivity extends ChessActivity {
             history.add(getFEN());
             historyIndex = 0;
             updateBestMove();
-        });dateBestMove();
         });
     }
 


### PR DESCRIPTION
## Summary
- fix leftover text in `AnalysisChessActivity`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68654db642c88333a5822d696491572e