### PR TITLE
Handle offline mode for AI and analysis

### DIFF
--- a/app/src/main/java/de/brockmann/chessinterface/AIChessActivity.java
+++ b/app/src/main/java/de/brockmann/chessinterface/AIChessActivity.java
@@ -5,6 +5,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
+import android.widget.Toast;
 
 /**
  * Chess activity against the Stockfish engine.
@@ -26,8 +27,14 @@ public class AIChessActivity extends ChessActivity {
 
         aiStrength = getIntent().getIntExtra(MenuAIActivity.EXTRA_AI_STRENGTH, 800);
         aiColor = getIntent().getCharExtra(MenuAIActivity.EXTRA_AI_COLOR, 'B');
-        engine = new StockfishClient();
-        engine.start();
+
+        if (hasInternetConnection()) {
+            engine = new StockfishClient();
+            engine.start();
+        } else {
+            engine = null;
+            Toast.makeText(this, R.string.no_internet, Toast.LENGTH_LONG).show();
+        }
 
         // only allow resignation in AI mode
         Button draw = findViewById(R.id.btn_offer_draw);
@@ -57,6 +64,7 @@ public class AIChessActivity extends ChessActivity {
     }
 
     private void makeAIMove() {
+        if (engine == null) return;
         new Thread(() -> {
             String fen = getFEN();
             int depth = 8 + (aiStrength - 800) / 200;

--- a/app/src/main/java/de/brockmann/chessinterface/AnalysisChessActivity.java
+++ b/app/src/main/java/de/brockmann/chessinterface/AnalysisChessActivity.java
@@ -3,6 +3,7 @@ package de.brockmann.chessinterface;
 import android.os.Bundle;
 import android.widget.Button;
 import android.widget.FrameLayout;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,8 +23,13 @@ public class AnalysisChessActivity extends ChessActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        engine = new StockfishClient();
-        engine.start();
+        if (hasInternetConnection()) {
+            engine = new StockfishClient();
+            engine.start();
+        } else {
+            engine = null;
+            Toast.makeText(this, R.string.no_internet, Toast.LENGTH_LONG).show();
+        }
         arrowView = findViewById(R.id.best_move_arrow);
         if (arrowView != null) {
             arrowView.bringToFront();

--- a/app/src/main/java/de/brockmann/chessinterface/ChessActivity.java
+++ b/app/src/main/java/de/brockmann/chessinterface/ChessActivity.java
@@ -6,6 +6,12 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkInfo;
+import android.os.Build;
 import android.view.DragEvent;
 import android.view.Gravity;
 import android.view.View;
@@ -859,5 +865,19 @@ public abstract class ChessActivity extends AppCompatActivity {
 
         setupBoardCells();
         placePiecesOnBoard();
+    }
+
+    protected boolean hasInternetConnection() {
+        ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (cm == null) return false;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Network network = cm.getActiveNetwork();
+            if (network == null) return false;
+            NetworkCapabilities nc = cm.getNetworkCapabilities(network);
+            return nc != null && nc.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
+        } else {
+            NetworkInfo ni = cm.getActiveNetworkInfo();
+            return ni != null && ni.isConnected();
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">ChessInterface</string>
+    <string name="no_internet">No internet connection</string>
     <string-array name="time_controls">
         <item>Keine Zeitkontrolle</item>
         <item>1</item>


### PR DESCRIPTION
## Summary
- add network check helper to ChessActivity
- show a toast when there's no internet in AI and Analysis modes
- skip Stockfish engine initialization without connectivity

## Testing
- `./gradlew test --no-daemon` *(fails: unable to download Gradle due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_686555897c708333a5eddeaadc5da6ed